### PR TITLE
Parameterized IOC Shell Scripts to initialize octal modules

### DIFF
--- a/drvIpac/ipacRelease.html
+++ b/drvIpac/ipacRelease.html
@@ -26,6 +26,10 @@ version appears at the bottom, with more recent releases above it.</P>
 
 <LI>Adjusted various <TT>#include</TT> lines to follow the rules for building
   shared libraries on Windows.</LI>
+	
+<LI>IOC shell scripts were added to easily initialize IP-Octal and ip520 modules.
+  Further information about these scripts can be found in their respective documentation
+  and at https://github.com/epics-modules/xxx/wiki/IOC-Shell-Scripts</LI>
 
 </UL>
 

--- a/drvIpac/ipacRelease.html
+++ b/drvIpac/ipacRelease.html
@@ -29,7 +29,7 @@ version appears at the bottom, with more recent releases above it.</P>
 	
 <LI>IOC shell scripts were added to easily initialize IP-Octal and ip520 modules.
   Further information about these scripts can be found in their respective documentation
-  and at https://github.com/epics-modules/xxx/wiki/IOC-Shell-Scripts</LI>
+  and <a href=https://github.com/epics-modules/xxx/wiki/IOC-Shell-Scripts>in the xxx module wiki</a></LI>
 
 </UL>
 

--- a/iocsh/ip520.iocsh
+++ b/iocsh/ip520.iocsh
@@ -1,0 +1,34 @@
+# ### ip520.iocsh ###
+
+#- ###################################################
+#- INSTANCE         - Name by which you want to refer to this IndustryPack module
+#- INT_VEC          - Interrupt Vector
+#- PORT             - Optional: tyGSOctal port name prefix, this script will create 8 
+#-                              ports named $(PORT)0 ... $(PORT)7
+#-                    Default: /tyGS/$(CARRIER),$(SLOT)/
+#-
+#- CARRIER          - Optional: number of IP carrier (Carriers are numbered in the order 
+#-                              in which they were defined in ipacAddXYZ() calls.)
+#-                    Default: 0
+#-
+#- SLOT             - Optional: location of module on carrier -- 0..3 for slot A..slot D
+#-                    Default: 0
+#-
+#- MAX_MODULES      - Optional: Max number of tyGSOctal modules that will be configured
+#-                    Default: 1
+#-
+#- IN_BUFF          - Optional: Read buffer size
+#-                    Defult: 1000
+#-
+#- OUT_BUFF         - Optional: Write buffer size
+#-                    Default: 1000
+#-
+#- ###################################################
+
+# Initialize Octal UART stuff
+$(IP520_INIT_COMPLETE="") IP520Drv($(MAX_MODULES=1))
+
+IP520ModuleInit("$(INSTANCE)", "232", $(INT_VEC), $(CARRIER=0), $(SLOT=0))
+IP520DevCreateAll("$(PORT=/tyGS/$(CARRIER=0),$(SLOT=0)/)", "$(INSTANCE)", 1000, 1000)
+
+epicsEnvSet("IP520_INIT_COMPLETE", "#")

--- a/iocsh/tyGSOctal.iocsh
+++ b/iocsh/tyGSOctal.iocsh
@@ -1,0 +1,35 @@
+# ### tyGSOctal.iocsh ###
+
+#- ###################################################
+#- INSTANCE         - Name by which you want to refer to this IndustryPack module
+#- TYPE             - Serial hardware standard the module implements (232, 422, or 485)
+#- INT_VEC          - Interrupt Vector
+#- PORT             - Optional: tyGSOctal port name prefix, this script will create 8 
+#-                              ports named $(PORT)0 ... $(PORT)7
+#-                    Default: /tyGS/$(CARRIER),$(SLOT)/
+#-
+#- CARRIER          - Optional: number of IP carrier (Carriers are numbered in the order 
+#-                              in which they were defined in ipacAddXYZ() calls.)
+#-                    Default: 0
+#-
+#- SLOT             - Optional: location of module on carrier -- 0..3 for slot A..slot D
+#-                    Default: 0
+#-
+#- MAX_MODULES      - Optional: Max number of tyGSOctal modules that will be configured
+#-                    Default: 1
+#-
+#- IN_BUFF          - Optional: Read buffer size
+#-                    Defult: 1000
+#-
+#- OUT_BUFF         - Optional: Write buffer size
+#-                    Default: 1000
+#-
+#- ###################################################
+
+# Initialize Octal UART stuff
+$(TYGSOCTAL_INIT_COMPLETE="") tyGSOctalDrv($(MAX_MODULES=1))
+
+tyGSOctalModuleInit("$(INSTANCE)", "$(TYPE)", $(INT_VEC), $(CARRIER=0), $(SLOT=0))
+tyGSOctalDevCreateAll("$(PORT=/tyGS/$(CARRIER=0),$(SLOT=0)/)", "$(INSTANCE)", 1000, 1000)
+
+epicsEnvSet("TYGSOCTAL_INIT_COMPLETE", "#")

--- a/ip520/IP520.html
+++ b/ip520/IP520.html
@@ -104,5 +104,42 @@ IP520Config "/tyGS/0,0/0", 38400, 'N', 1, 8, 'N'
 </pre>
 </blockquote>
 
+<p>Alternately, for those using EPICS base 3.15 or higher, the iocshLoad command can be used with 
+the ip520.iocsh script included in the top-level iocsh directory. The following is an example of
+such a use.</p>
+
+<blockquote>
+<pre>
+# Initialize the drvIpac carriers.
+# -------------------------------
+# carrier#0
+ipacAddMVME162    "A:m=0xe0000000,64 l=3,2"
+# carrier#1
+ipacAddVIPC616_01 "0x6400,0xB0000000"
+# carrier#2
+ipacAddTVME200    "602fb00"
+
+# Initialize a ip520 module called MOD0 that's located in slot A of
+# of the first initialized carrier (MVME162), and then create 8 tty 
+# ports labeled /tyGS/0,0/0 through /tyGS/0,0/7 on that module.
+# Also tell the support that you will be initializing up to 5 more modules.
+iocshLoad("$(IPAC)/iocsh/ip520.iocsh", "INSTANCE=MOD0, INT_VEC=0x80, CARRIER=0, SLOT=0, MAX_MODULES=6")
+
+# Initialize the ip520 module in slot B of the MVME162, the tty ports
+# created will be labeled /tyGS/0,1/0 through /tyGS/0,1/7
+iocshLoad("$(IPAC)/iocsh/ip520.iocsh", "INSTANCE=MOD1, INT_VEC=0x81, CARRIER=0, SLOT=1")
+
+# Init two IP520 modules from the 1st SBS VIPC616_01 carrier; the 1st
+# module is in slot A, the 2nd module is in slot C.
+iocshLoad("$(IPAC)/iocsh/ip520.iocsh", "INSTANCE=MOD2, INT_VEC=0x82, CARRIER=1, SLOT=0")
+iocshLoad("$(IPAC)/iocsh/ip520.iocsh", "INSTANCE=MOD3, INT_VEC=0x83, CARRIER=1, SLOT=2")
+
+# Init two IP520 modules from the 2nd SBS VIPC616_01 carrier; the 1st
+# module is in slot B, the second module is in slot D.
+iocshLoad("$(IPAC)/iocsh/ip520.iocsh", "INSTANCE=MOD4, INT_VEC=0x84, CARRIER=2, SLOT=1")
+iocshLoad("$(IPAC)/iocsh/ip520.iocsh", "INSTANCE=MOD5, INT_VEC=0x85, CARRIER=2, SLOT=3")
+</pre>
+</blockquote>
+
 </body>
 </html>

--- a/tyGSOctal/tyGSOctal.html
+++ b/tyGSOctal/tyGSOctal.html
@@ -105,6 +105,45 @@ tyGSOctalConfig "/tyGS/0,0/0", 38400, 'N', 1, 8, 'N'
   </pre>
 </blockquote>
 
+<p>Alternately, for those using EPICS base 3.15 or higher, the iocshLoad command can be used with 
+the tyGSOctal.iocsh script included in the top-level iocsh directory. The following is an example of
+such a use.</p>
+
+<blockquote>
+<pre>
+# Initialize the drvIpac carriers.
+# -------------------------------
+# carrier#0
+ipacAddMVME162    "A:m=0xe0000000,64 l=3,2"
+# carrier#1
+ipacAddVIPC616_01 "0x6400,0xB0000000"
+# carrier#2
+ipacAddTVME200    "602fb00"
+
+# Initialize a IP-Octal module called MOD0 that's located in slot A of
+# of the first initialized carrier (MVME162), and then create 8 tty 
+# ports labeled /tyGS/0,0/0 through /tyGS/0,0/7 on that module.
+# Also tell the support that you will be initializing up to 5 more modules.
+iocshLoad("$(IPAC)/iocsh/tyGSOctal.iocsh", "INSTANCE=MOD0, INT_VEC=0x80, CARRIER=0, SLOT=0, TYPE=232, MAX_MODULES=6")
+
+# Initialize the IP-Octal module in slot B of the MVME162, the tty ports
+# created will be labeled /tyGS/0,1/0 through /tyGS/0,1/7
+iocshLoad("$(IPAC)/iocsh/tyGSOctal.iocsh", "INSTANCE=MOD1, INT_VEC=0x81, CARRIER=0, SLOT=1, TYPE=232")
+
+# Init two IP-Octal modules from the 1st SBS VIPC616_01 carrier; the 1st
+# module is in slot A, the 2nd module is in slot C.
+iocshLoad("$(IPAC)/iocsh/tyGSOctal.iocsh", "INSTANCE=MOD2, INT_VEC=0x82, CARRIER=1, SLOT=0, TYPE=232")
+iocshLoad("$(IPAC)/iocsh/tyGSOctal.iocsh", "INSTANCE=MOD3, INT_VEC=0x83, CARRIER=1, SLOT=2, TYPE=232")
+
+# Init two IP-Octal modules from the 2nd SBS VIPC616_01 carrier; the 1st
+# module is in slot B, the second module is in slot D. Both will implement
+# RS485 instead of RS232
+iocshLoad("$(IPAC)/iocsh/tyGSOctal.iocsh", "INSTANCE=MOD4, INT_VEC=0x84, CARRIER=2, SLOT=1, TYPE=485")
+iocshLoad("$(IPAC)/iocsh/tyGSOctal.iocsh", "INSTANCE=MOD5, INT_VEC=0x85, CARRIER=2, SLOT=3, TYPE=485")
+</pre>
+</blockquote>
+
+
 <h2>RTEMS</h2>
 
 <p>The RTEMS version of this driver provides a similar set of commands.


### PR DESCRIPTION
This pull request is part of a series of pull requests to try and move all device/module specific IOC support into their respective epics modules. This will not only make the xxx startup scripts much easier to maintain, understand, and update, but this will make sure that support is more likely to be kept up to date as the people who are designing the device support are the ones keeping track of the shell scripts.

[Further Information](https://github.com/epics-modules/xxx/wiki/IOC-Shell-Scripts)